### PR TITLE
Serial Number Entry

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -85,10 +85,12 @@
 
     .form-container {
         position: relative;
-        display: grid;
-        grid-template-rows: 1fr 1fr;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
         padding: 1rem;
         height: 100vh;
+        overflow-y: auto;
     }
 
     .form-container div {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,7 @@
     import { labelFormats } from "./companies";
     import LabelForm from "./components/LabelForm.svelte";
     import FormatSelector from "./components/FormatSelector.svelte";
+    import SerialNumberInput from "./components/SerialNumberInput.svelte";
 
     const NETWORK_ERROR_MESSAGE = "Network error. Please try again later.";
     const STATE_FETCH_FAIL_MESSAGE = "Failed to fetch application state.";
@@ -20,7 +21,8 @@
         loading: true,
     };
 
-    let active: number | null = null;
+    // let active: number | null = null;
+    let active: number | null = 0;
 
     onMount(async () => {
         fetch("/api/state")
@@ -66,6 +68,7 @@
         {#each labelFormats as labelFormat, itemIndex}
             <div class:active={itemIndex === active}>
                 <LabelForm {labelFormat} />
+                <SerialNumberInput />
             </div>
         {/each}
     </div>
@@ -82,7 +85,13 @@
     }
 
     .form-container div.active {
-        display: block;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+
+        padding: 1rem;
+        height: 100vh;
     }
 
     .form-container h2 {
@@ -91,5 +100,24 @@
         align-items: center;
 
         height: 100%;
+    }
+
+    :global(button) {
+        border: none;
+        background-color: var(--button-bg, #111);
+        color: var(--text);
+        font-size: 1rem;
+        cursor: pointer;
+    }
+    :global(button:hover) {
+        background-color: var(--button-bg-hover, #333);
+    }
+
+    :global(h1) {
+        font-size: 2.5rem;
+    }
+
+    :global(input) {
+        font-size: 1.25rem;
     }
 </style>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -22,7 +22,7 @@
     };
 
     // Set to `null` in production.
-    let active: number | null = 0;
+    let active: number | null = null;
 
     onMount(async () => {
         fetch("/api/state")

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -21,7 +21,8 @@
         loading: true,
     };
 
-    let active: number | null = null;
+    // Set to `null` in production.
+    let active: number | null = 0;
 
     onMount(async () => {
         fetch("/api/state")

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -21,8 +21,7 @@
         loading: true,
     };
 
-    // let active: number | null = null;
-    let active: number | null = 0;
+    let active: number | null = null;
 
     onMount(async () => {
         fetch("/api/state")
@@ -62,15 +61,18 @@
 
     <div class="form-container">
         {#if active === null}
-            <h2>{NO_FORMAT_SELECTED_MESSAGE}</h2>
+            <h2 class="hero">{NO_FORMAT_SELECTED_MESSAGE}</h2>
         {/if}
 
         {#each labelFormats as labelFormat, itemIndex}
             <div class:active={itemIndex === active}>
                 <LabelForm {labelFormat} />
-                <SerialNumberInput />
             </div>
         {/each}
+
+        {#if active !== null}
+            <SerialNumberInput />
+        {/if}
     </div>
 </main>
 
@@ -80,37 +82,46 @@
         grid-template-columns: 300px 2fr;
     }
 
+    .form-container {
+        position: relative;
+        display: grid;
+        grid-template-rows: 1fr 1fr;
+        padding: 1rem;
+        height: 100vh;
+    }
+
     .form-container div {
         display: none;
     }
 
     .form-container div.active {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 1rem;
-
-        padding: 1rem;
-        height: 100vh;
+        display: block;
     }
 
     .form-container h2 {
         display: flex;
         justify-content: center;
         align-items: center;
-
         height: 100%;
+    }
+
+    .hero {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
     }
 
     :global(button) {
         border: none;
-        background-color: var(--button-bg, #111);
+        background-color: var(--accent);
         color: var(--text);
         font-size: 1rem;
         cursor: pointer;
     }
+
     :global(button:hover) {
-        background-color: var(--button-bg-hover, #333);
+        background-color: var(--accent-hover);
     }
 
     :global(h1) {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -2,23 +2,23 @@
 
 @media (prefers-color-scheme: light) {
     :root {
+        --background: #eee;
+        --accent: #6cf;
+        --accent-hover: #2ad;
         --text: #111;
-        --background: #e6e6e6;
-        --background-2: #ddd;
-        --primary: #add1db;
-        --secondary: #28a4c3;
-        --accent: #46a4a4;
+        --text-muted: #444;
+        --bd: solid 1px var(--text-muted);
     }
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --text: #f5f5f4;
-        --background: #1a1a1a;
-        --background-2: #2a2a2a;
-        --primary: #244852;
-        --secondary: #3cb8d7;
-        --accent: #6cd6d6;
+        --background: #222;
+        --accent: #111;
+        --accent-hover: #444;
+        --text: #eee;
+        --text-muted: #aaa;
+        --bd: solid 1px var(--text-muted);
     }
 }
 

--- a/frontend/src/companies.ts
+++ b/frontend/src/companies.ts
@@ -65,4 +65,4 @@ export let labelFormats: Array<CompanyLabelFormat> = [
         fields: ["PN", "Rev", "Job#", "SN", "PO/Line"],
         format: "..,.,.,.",
     },
-];
+].sort((a, b) => a.company < b.company ? -1 : 1);

--- a/frontend/src/components/FormatSelector.svelte
+++ b/frontend/src/components/FormatSelector.svelte
@@ -10,7 +10,7 @@
         grid-template-rows: repeat(auto-fit, minmax(2rem, 1fr));
         padding: 1rem 0;
         height: 100vh;
-        background: var(--selector-bg, #000);
+        background: var(--accent);
         overflow-y: auto;
     }
 
@@ -23,6 +23,6 @@
     }
 
     .wrapper :global(*):hover {
-        background-color: var(--selector-hover, #fff4);
+        background-color: var(--accent-hover);
     }
 </style>

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -55,7 +55,6 @@
 
     fieldset > legend {
         margin: 0 auto 1rem;
-        padding: 0 0.5rem;
         font-size: 1.5rem;
     }
 

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -2,23 +2,25 @@
     export let labelFormat: { [key: string]: any };
 </script>
 
-<h1>{labelFormat.company}</h1>
+<span class="container">
+    <h1>{labelFormat.company}</h1>
 
-<form action="">
-    <fieldset>
-        <legend>Label Fields</legend>
-        {#each labelFormat.fields as field}
-            <label for="field">{field}</label>
-            <input type="text" id="field" name="field" />
-        {/each}
-    </fieldset>
-</form>
-
-<hr />
+    <form action="">
+        <fieldset>
+            <legend>Label Fields</legend>
+            {#each labelFormat.fields as field}
+                <label for="field">{field}</label>
+                <input type="text" id="field" name="field" />
+            {/each}
+        </fieldset>
+    </form>
+</span>
 
 <style>
-    :root {
-        --bd: solid 1px var(--text-muted, #fff8);
+    .container {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
     }
 
     form {
@@ -33,8 +35,16 @@
         align-items: center;
         gap: 1rem;
 
+        margin: 0 auto;
+        width: 50%;
         font-size: 1.5rem;
         border: none;
+    }
+
+    fieldset > input {
+        max-width: 600px;
+        min-width: 300px;
+        width: 100%;
     }
 
     fieldset > label {
@@ -54,12 +64,5 @@
         width: 100%;
         text-align: center;
         border-bottom: var(--bd);
-    }
-
-    hr {
-        display: block;
-        width: 100%;
-        border-top: var(--bd);
-        border-bottom: none;
     }
 </style>

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -1,55 +1,65 @@
 <script lang="ts">
-    import SerialNumberInput from "./SerialNumberInput.svelte";
     export let labelFormat: { [key: string]: any };
 </script>
 
+<h1>{labelFormat.company}</h1>
+
 <form action="">
     <fieldset>
-        <legend>{labelFormat.company}</legend>
-
+        <legend>Label Fields</legend>
         {#each labelFormat.fields as field}
-            <label for="field">{field}:</label>
+            <label for="field">{field}</label>
             <input type="text" id="field" name="field" />
         {/each}
-
-        <button type="submit">Print</button>
     </fieldset>
-
-    <SerialNumberInput />
 </form>
 
+<hr />
+
 <style>
+    :root {
+        --bd: solid 1px var(--text-muted, #fff8);
+    }
+
+    form {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+
     fieldset {
         display: grid;
         grid-template-columns: auto 1fr;
-        gap: 0.5rem;
+        align-items: center;
+        gap: 1rem;
 
-        padding: 1rem;
-        width: 300px;
-    }
-
-    fieldset > button {
-        grid-column: 1/-1;
-        margin-top: 0.5rem;
+        font-size: 1.5rem;
+        border: none;
     }
 
     fieldset > label {
+        padding-left: 1rem;
         text-align: right;
         white-space: nowrap;
     }
 
     fieldset > legend {
-        margin: 0 auto;
+        margin: 0 auto 1rem;
         padding: 0 0.5rem;
         font-size: 1.5rem;
     }
 
-    form {
-        display: grid;
-        grid-template-columns: 300px 300px;
+    h1 {
+        padding-bottom: 0.75rem;
+        width: 100%;
+        text-align: center;
+        border-bottom: var(--bd);
     }
 
-    :global(.sn-input) {
-        margin-top: 0.5rem;
+    hr {
+        display: block;
+        width: 100%;
+        border-top: var(--bd);
+        border-bottom: none;
     }
 </style>

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -1,24 +1,36 @@
 <script lang="ts"></script>
 
-<span>
-    <h1>Serial Numbers</h1>
-    <h3>&lpar;Enter zero or more&rpar;</h3>
+<span class="container">
+    <span>
+        <h1>Serial Numbers</h1>
+        <h3>&lpar;Enter zero or more&rpar;</h3>
+    </span>
+
+    <div>
+        <input type="text" />
+        <button>Add</button>
+        <button>Increment</button>
+    </div>
+
+    <ul class="sn-list"></ul>
 </span>
 
-<div>
-    <input type="text" />
-    <button>Add</button>
-    <button>Increment</button>
-</div>
-
-<ul class="sn-list"></ul>
-
 <style>
+    .container {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        border-top: var(--bd);
+    }
+
     div {
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-template-rows: 1fr 1fr;
-
+        min-width: 320px;
         width: 50%;
     }
 

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -1,4 +1,39 @@
-<script lang="ts"></script>
+<script lang="ts">
+    import { writable } from "svelte/store";
+
+    let serialNumber = "";
+    const serialNumberList = writable<string[]>([]);
+    const lastSerialNumber = () => $serialNumberList.at(-1);
+
+    const addSN = (input: string = serialNumber, clear = true) => {
+        if (input === "") return;
+
+        serialNumberList.update((list) => [...list, input]);
+        if (clear) serialNumber = "";
+    };
+
+    const incrementSN = (input: string | undefined = lastSerialNumber()) => {
+        if (input === "" || input === undefined) return;
+
+        const match = input!.match(/^([a-zA-Z-]*)(\d+$)/);
+
+        if (!match) return;
+
+        const [_, prefix, num] = match;
+        const incremented = parseInt(num, 10) + 1;
+        const newSerialNumber = `${prefix}${incremented}`;
+
+        return newSerialNumber;
+    };
+
+    /** Remove a serial number given its index */
+    const removeSN = (index: number) => {
+        serialNumberList.update((list) => {
+            list.splice(index, 1);
+            return list;
+        });
+    };
+</script>
 
 <span class="container">
     <span>
@@ -7,12 +42,19 @@
     </span>
 
     <div>
-        <input type="text" />
-        <button>Add</button>
-        <button>Increment</button>
+        <input type="text" bind:value={serialNumber} />
+        <button on:click={() => addSN()}>Add</button>
+        <button on:click={() => addSN(incrementSN(), false)}>Increment</button>
     </div>
 
-    <ul class="sn-list"></ul>
+    <ul class="serial-number-list">
+        {#each $serialNumberList as sn, index}
+            <li class="serial-number">
+                <p>{sn}</p>
+                <button on:click={() => removeSN(index)}>Remove</button>
+            </li>
+        {/each}
+    </ul>
 </span>
 
 <style>
@@ -24,6 +66,19 @@
         gap: 1rem;
         padding: 1rem;
         border-top: var(--bd);
+    }
+
+    .serial-number {
+        display: flex;
+    }
+
+    .serial-number-list {
+        display: grid;
+        grid-template-rows: repeat(3, auto);
+        grid-template-columns: repeat(auto-fill, 1fr);
+        gap: 0.5rem 1rem;
+
+        list-style-type: none;
     }
 
     div {

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -175,10 +175,6 @@
         `min-width: 0` is required to prevent another class `.serial-number-display` from
         expanding beyond the container's width (enabling it to scroll horizontally).
 
-        This is because the container of THIS class is a grid container, which cannot
-        contain items exceeding its own size, therefore the default values for `min-width`
-        and `min-height` are `auto`, which is undesired in this case.
-
         A full explanation can be found here:
         https://stackoverflow.com/questions/61959291/how-to-get-scrolling-in-a-css-grid
 

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -145,6 +145,9 @@
                         title="Double-click to edit"
                         on:dblclick={() => {
                             editIndex = index;
+
+                            // Focus the input after it has been rendered.
+                            setTimeout(() => snEditor.focus(), 0);
                         }}
                     >
                         {sn}

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -1,11 +1,34 @@
 <script lang="ts"></script>
 
+<span>
+    <h1>Serial Numbers</h1>
+    <h3>&lpar;Enter zero or more&rpar;</h3>
+</span>
+
 <div>
     <input type="text" />
     <button>Add</button>
     <button>Increment</button>
-
-    <ul class="sn-list"></ul>
 </div>
 
-<style></style>
+<ul class="sn-list"></ul>
+
+<style>
+    div {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+
+        width: 50%;
+    }
+
+    input {
+        grid-column: 1/-1;
+    }
+
+    span {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+</style>

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -9,12 +9,21 @@
     const serialNumberList = writable<string[]>([]);
     const lastSerialNumber = () => $serialNumberList.at(-1);
 
+    /**
+     * Add a serial number to the list.
+     * @param input Value to be added to the list.
+     * @param clear Whether to clear the input after adding the value.
+     */
     const addSN = (input: string = serialNumber, clear = true) => {
         if (input === "") return;
+
+        // Prevent duplicates
         if ($serialNumberList.includes(input)) return;
 
         serialNumberList.update((list) => [...list, input]);
 
+        // Delay the scroll to the end of the list to ensure
+        // that the width of the element has been updated.
         setTimeout(
             () =>
                 (serialNumberDisplay.scrollLeft =
@@ -25,8 +34,15 @@
         if (clear) serialNumber = "";
     };
 
+    /**
+     * Edit a serial number given its index.
+     * @param index Index of the serial number to be updated.
+     * @param value New value to be assigned to the serial number.
+     */
     const editSN = (index: number, value: string | null) => {
         if (value === null) return;
+
+        // Prevent duplicates
         if ($serialNumberList.includes(value)) return;
 
         serialNumberList.update((list) => {
@@ -34,12 +50,21 @@
             return list;
         });
 
+        // End the editing operation
         editIndex = null;
     };
 
+    /**
+     * Increment the last serial number in the list.
+     * @param input The last serial number in the list.
+     */
     const incrementSN = (input: string | undefined = lastSerialNumber()) => {
+        // Prevent incrementing an empty list
         if (input === "" || input === undefined) return;
 
+        // Matches the following formats (prefix is optional):
+        // 1. "ABC123" => ["ABC", "123"]
+        // 2. "ABC-123" => ["ABC-", "123"]
         const match = input!.match(/^([a-zA-Z-]*)(\d+$)/);
 
         if (!match) return;
@@ -52,8 +77,13 @@
         return `${prefix}${incremented}`;
     };
 
-    /** Remove a serial number given its index */
+    /**
+     * Remove a serial number from the list.
+     * @param index Index of the serial number to be removed.
+     */
     const removeSN = (index: number) => {
+        // Cancel any editing operations
+        editIndex = null;
         serialNumberList.update((list) => {
             list.splice(index, 1);
             return list;
@@ -67,7 +97,7 @@
         <h3>&lpar;Enter zero or more&rpar;</h3>
     </span>
 
-    <div>
+    <div class="serial-number-input">
         <input
             type="text"
             bind:value={serialNumber}
@@ -81,17 +111,25 @@
                 }
             }}
         />
-        <button on:click={() => addSN()}>Add</button>
-        <button on:click={() => addSN(incrementSN(), false)}>Increment</button>
+
+        <button on:click={() => addSN()} title="Add a Serial Number">
+            Add
+        </button>
+        <button
+            on:click={() => addSN(incrementSN(), false)}
+            title="Increment the previous Serial Number"
+        >
+            Increment
+        </button>
     </div>
 
-    <ul class="serial-number-list" bind:this={serialNumberDisplay}>
+    <ul class="serial-number-display" bind:this={serialNumberDisplay}>
         {#each $serialNumberList as sn, index}
             <li class="serial-number">
                 {#if editIndex === index}
+                    <!-- Individual Serial Number Editor -->
                     <input
                         type="text"
-                        contenteditable="true"
                         value={sn}
                         bind:this={snEditor}
                         on:keydown={(e) => {
@@ -102,7 +140,9 @@
                         }}
                     />
                 {:else}
+                    <!-- Individual Serial Number -->
                     <p
+                        title="Double-click to edit"
                         on:dblclick={() => {
                             editIndex = index;
                         }}
@@ -129,7 +169,7 @@
 
         /*
         
-        `min-width: 0` is required to prevent another class `.serial-number-list` from
+        `min-width: 0` is required to prevent another class `.serial-number-display` from
         expanding beyond the container's width (enabling it to scroll horizontally).
 
         This is because the container of THIS class is a grid container, which cannot
@@ -146,7 +186,7 @@
         border-top: var(--bd);
     }
 
-    .serial-number-list {
+    .serial-number-display {
         display: grid;
         grid-auto-flow: column;
         grid-template-rows: repeat(7, auto);
@@ -174,6 +214,8 @@
         align-items: center;
         padding: 0 0.5rem;
         height: 100%;
+        border: none;
+        color: var(--text);
         background-color: #fff3;
     }
 
@@ -185,7 +227,7 @@
         width: 50%;
     }
 
-    input {
+    .serial-number-input input {
         grid-column: 1/-1;
     }
 


### PR DESCRIPTION
# Changes in this PR
Fixes #2

- Added the `<SerialNumberInput />` component
    - Input for serial number entry
    - **Add** button to push a single value
    - **Increment** button to push a value of (n<sub>-1</sub>)+1
        - Currently only supports serial numbers which end numerically
        - Supports non-numerical prefixes (eg. `SN-0001` => `SN-0002`)
        - Zero-pads new values to the same length
- Individual serial numbers are listed in a horizontally scrolling grid
    - Each serial number can be edited via double-click
        - Input validation prevents duplicate values
        - Same value cancels the operation
    - Each serial number can be removed with its respective **Remove** button

## UI Changes
- Added color definitions to the global stylesheet (and actually utilized them)
- `.form-container` is now a flexbox container and scrolls vertically at small scales
- Adjusted size and spacing of `<LabelForm />` elements
- Display for `NO_FORMAT_SELECTED_MESSAGE` is now positioned absolutely
- Sorted label format names alphabetically