### PR TITLE
Restructure Label Formats

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,7 +8,7 @@
 
     const NETWORK_ERROR_MESSAGE = "Network error. Please try again later.";
     const STATE_FETCH_FAIL_MESSAGE = "Failed to fetch application state.";
-    const NO_FORMAT_SELECTED_MESSAGE = "No label format selected.";
+    const NO_FORMAT_SELECTED_MESSAGE = "No label format selected.";    
 
     interface AppState {
         app_title?: string;

--- a/frontend/src/companies.ts
+++ b/frontend/src/companies.ts
@@ -1,68 +1,55 @@
 interface CompanyLabelFormat {
     company: string;
-    fields: string[];
-    format: string;
+    rows: string[][];
 }
 
 export let labelFormats: Array<CompanyLabelFormat> = [
     {
         company: "Bell/ITT",
-        fields: ["PN", "Rev", "DOM", "Job#", "P Date", "P Code", "Class"],
-        format: "..,..,..,.",
+        rows: [["PN", "Rev"], ["DOM", "Job#"], ["P Date", "P Code"], ["Class"]],
     },
     {
         company: "Kidde",
-        fields: ["PN", "Rev", "DOM", "Job#"],
-        format: "..,..",
+        rows: [["PN", "Rev"], ["DOM", "Job#"]],
     },
     {
         company: "Ontic",
-        fields: ["PN", "Rev", "Job#"],
-        format: "..,.",
+        rows: [["PN", "Rev"], ["Job#"]],
     },
     {
         company: "Biomet",
-        fields: ["PN", "Rev"],
-        format: ".,.",
+        rows: [["PN"], ["Rev"]],
     },
     {
         company: "Linvatec",
-        fields: ["PN", "Rev"],
-        format: ".,.",
+        rows: [["PN"], ["Rev"]],
     },
     {
         company: "Purolator",
-        fields: ["PN", "Rev"],
-        format: ".,.",
+        rows: [["PN"], ["Rev"]],
     },
     {
         company: "Curtiss Wright",
-        fields: ["PN"],
-        format: ".",
+        rows: [["PN"]],
     },
     {
         company: "Lord",
-        fields: ["PN", "Class"],
-        format: ".,.",
+        rows: [["PN"], ["Class"]],
     },
     {
         company: "Sierra Nevada",
-        fields: ["PN", "Rev", "Job#", "Thread Insp."],
-        format: "..,.,.",
+        rows: [["PN", "Rev"], ["Job#"], ["Thread Insp."]],
     },
     {
         company: "Dover",
-        fields: ["PN", "Rev"],
-        format: ".,.",
+        rows: [["PN"], ["Rev"]],
     },
     {
         company: "Moog",
-        fields: ["PN", "Rev", "Job#", "PO#"],
-        format: "..,.,.",
+        rows: [["PN", "Rev"], ["Job#"], ["PO#"]],
     },
     {
         company: "SpaceX",
-        fields: ["PN", "Rev", "Job#", "SN", "PO/Line"],
-        format: "..,.,.,.",
+        rows: [["PN", "Rev"], ["Job#"], ["SN"], ["PO/Line"]],
     },
 ].sort((a, b) => a.company < b.company ? -1 : 1);

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -6,9 +6,11 @@
 <span class="container {active ? 'active' : ''}">
     <h1>Label Fields</h1>
     <form action="">
-        {#each format.fields as field}
-            <label for="field">{field}</label>
-            <input type="text" id="field" name="field" />
+        {#each format.rows as row}
+            {#each row as field}
+                <label for="field">{field}</label>
+                <input type="text" id={field} name={field} />
+            {/each}
         {/each}
     </form>
 </span>


### PR DESCRIPTION
# Changes in this PR
- `CompanyLabelFormat` interface has been updated
    - `fields: string[]` &rarr; `rows: string[][]`
    - Removed `format: string`
- Existing label formats have been updated to reflect this change
- `LabelForm.svelte` includes a nested loop to flatten each array within `rows`