### PR TITLE
Form Validation & Serialization

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { activeForm } from "./stores.js";
     import { onMount } from "svelte";
     import { labelFormats } from "./companies";
     import FormatSelector from "./components/FormatSelector.svelte";
@@ -24,7 +25,8 @@
     };
 
     // Set to `null` in production.
-    let active: number | null = null;
+    let active: number | null;
+    activeForm.subscribe((value) => (active = value));
 
     onMount(async () => {
         fetch("/api/state")
@@ -44,24 +46,20 @@
                 state.loading = false;
             });
     });
-
-    const displayForm = (index: number) => {
-        active = index;
-    };
 </script>
 
 <Header {state} />
 
 <main>
     <FormatSelector>
-        {#each labelFormats as labelFormat, i}
+        {#each labelFormats as labelFormat, index}
             <!-- TODO: Fix these -->
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
             <h2
-                data-item={i}
-                on:click={() => displayForm(i)}
-                class={active === i ? "active" : ""}
+                data-item={index}
+                on:click={() => activeForm.update(() => index)}
+                class={active === index ? "active" : ""}
             >
                 {labelFormat.company}
             </h2>

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -1,15 +1,35 @@
 <script lang="ts">
+    import { checkValidity, formDataStore, formValidity } from "../stores";
+
     export let format: { [key: string]: any };
     export let active: boolean = false;
+
+    let form: HTMLFormElement;
+
+    const updateDataStore = () => {
+        if (!active) return;
+
+        formDataStore.update(() => {
+            return { ...Object.fromEntries(new FormData(form)) };
+        });
+    };
+
+    $: if (active && $checkValidity) {
+        if (form.checkValidity()) formValidity.set(true);
+        else formValidity.set(false);
+
+        form.reportValidity();
+        checkValidity.set(false);
+    }
 </script>
 
 <span class="container {active ? 'active' : ''}">
     <h1>Label Fields</h1>
-    <form action="">
+    <form bind:this={form} on:input={updateDataStore}>
         {#each format.rows as row}
             {#each row as field}
                 <label for="field">{field}</label>
-                <input type="text" id={field} name={field} />
+                <input required type="text" id={field} name={field} />
             {/each}
         {/each}
     </form>

--- a/frontend/src/components/PrintingOptions.svelte
+++ b/frontend/src/components/PrintingOptions.svelte
@@ -1,12 +1,38 @@
 <script lang="ts">
+    import {
+        checkValidity,
+        formDataStore,
+        formValidity,
+        serialNumberList,
+    } from "../stores";
+
     let printDuplicates: boolean = false;
     let specifyQty: boolean = false;
     let duplicateAmount: number = 0;
     let specifiedQty: number = 1;
 
-    // TODO
-    const handleSubmit = (e: Event) => {
-        console.log("Printing Options Submitted");
+    const handleSubmit = async () => {
+        checkValidity.set(true);
+
+        // Wait for form validation
+        await new Promise((res) => setTimeout(res, 0));
+        if (!$formValidity) {
+            console.error("Form is invalid.");
+            return;
+        }
+
+        formDataStore.update((data) => {
+            return {
+                ...data,
+                printDuplicates: printDuplicates,
+                specifyQty: specifyQty,
+                duplicateAmount: duplicateAmount,
+                specifiedQty: specifiedQty,
+                serialNumberList: $serialNumberList,
+            };
+        });
+
+        // TODO: Build Fetch API Request
     };
 </script>
 

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -1,13 +1,23 @@
 <script lang="ts">
-    import { writable } from "svelte/store";
+    import { serialNumberList } from "../stores";
 
     let serialNumberDisplay: HTMLUListElement;
     let snEditor: HTMLInputElement;
     let editIndex: number | null = null;
     let serialNumber = "";
 
-    const serialNumberList = writable<string[]>([]);
     const lastSerialNumber = () => $serialNumberList.at(-1);
+
+    const scrollDisplay = () => {
+        // Delay the scroll to the end of the list to ensure
+        // that the width of the element has been updated.
+        setTimeout(
+            () =>
+                (serialNumberDisplay.scrollLeft =
+                    serialNumberDisplay.scrollWidth),
+            0,
+        );
+    };
 
     /**
      * Add a serial number to the list.
@@ -22,14 +32,7 @@
 
         serialNumberList.update((list) => [...list, input]);
 
-        // Delay the scroll to the end of the list to ensure
-        // that the width of the element has been updated.
-        setTimeout(
-            () =>
-                (serialNumberDisplay.scrollLeft =
-                    serialNumberDisplay.scrollWidth),
-            0,
-        );
+        scrollDisplay();
 
         if (clear) serialNumber = "";
     };

--- a/frontend/src/stores.ts
+++ b/frontend/src/stores.ts
@@ -1,0 +1,7 @@
+import { writable } from 'svelte/store';
+
+export const activeForm = writable<number | null>(null);
+export const checkValidity = writable<boolean>(false);
+export const formDataStore = writable<Object>({});
+export const formValidity = writable<boolean>(false);
+export const serialNumberList = writable<string[]>([]);


### PR DESCRIPTION
Fixes #3 

# Changes in This PR
- Clicking the **Print** button now serializes all inputs
    - Label Form data (all inputs are now `required`)
    - Serial Numbers
    - Printing Options

**THIS PR DOES NOT INCLUDE ANY LOGIC BEYOND SERIALIZATION.**

The following defaults are applied when their respective inputs are empty:
- `printDuplicates: false`
- `specifyQty: false`
- `duplicateAmount: 0`
- `specifiedQty: 1`
- `serialNumberList: []`