### PR TITLE
Preserve Row Groupings

### DIFF
--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -5,12 +5,23 @@
     export let active: boolean = false;
 
     let form: HTMLFormElement;
+    let rows: object[] = new Array(format.length);
+
+    const formObj = () => Object.fromEntries(new FormData(form));
 
     const updateDataStore = () => {
         if (!active) return;
 
+        // Group form data by row defined in format
+        let data = formObj();
+        format.rows.map((row: string[], index: number) => {
+            row.forEach((field: string) => {
+                rows[index] = { ...rows[index], [field]: data[field] };
+            });
+        });
+
         formDataStore.update(() => {
-            return { ...Object.fromEntries(new FormData(form)) };
+            return { rows: rows };
         });
     };
 
@@ -26,10 +37,16 @@
 <span class="container {active ? 'active' : ''}">
     <h1>Label Fields</h1>
     <form bind:this={form} on:input={updateDataStore}>
-        {#each format.rows as row}
+        {#each format.rows as row, index}
             {#each row as field}
-                <label for="field">{field}</label>
-                <input required type="text" id={field} name={field} />
+                <label for={field}>{field}</label>
+                <input
+                    required
+                    type="text"
+                    id={field}
+                    name={field}
+                    data-row-index={index}
+                />
             {/each}
         {/each}
     </form>

--- a/frontend/src/components/PrintingOptions.svelte
+++ b/frontend/src/components/PrintingOptions.svelte
@@ -33,6 +33,7 @@
         });
 
         // TODO: Build Fetch API Request
+        console.log($formDataStore);
     };
 </script>
 


### PR DESCRIPTION
Improves on fixes implemented in #3
# Changes in This PR
Form data now preserves the row to which each field belongs and passes form details as `rows: object[]`. This change will make it easier to define which fields should share a row or stay on a row of their own on each label.

## New Format for Request Data
![image](https://github.com/machspec/labelmaker3/assets/63938746/9e5f5e7b-647d-49cc-ac9e-527bda411d6f)
