### PR TITLE
Quality of Life Changes

### DIFF
--- a/frontend/src/components/Header.svelte
+++ b/frontend/src/components/Header.svelte
@@ -20,6 +20,7 @@
         padding: 0.5rem 1rem;
         height: 100%;
         background-color: var(--accent);
+        z-index: 99;
     }
 
     img {

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -59,11 +59,15 @@
                 />
             {/each}
         {/each}
+        <div class="form-options">
+            <button class="clear" on:click={() => form.reset()}>Clear</button>
+        </div>
     </form>
 </span>
 
 <style>
     .container {
+        position: relative;
         display: none;
     }
 
@@ -71,6 +75,17 @@
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
+    }
+
+    .form-options {
+        display: flex;
+        justify-content: flex-end;
+        grid-column: 1/-1;
+        width: 100%;
+    }
+
+    .form-options > button {
+        padding: 0.25rem 2rem;
     }
 
     form {
@@ -86,7 +101,6 @@
     }
 
     form > input {
-        max-width: 600px;
         min-width: 300px;
         width: 100%;
     }

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -14,6 +14,10 @@
 
     const formObj = () => Object.fromEntries(new FormData(form));
 
+    const clearForm = () => {
+        if (confirm("Clear all fields?")) form.reset();
+    };
+
     const updateDataStore = () => {
         if (!active) return;
 
@@ -60,7 +64,7 @@
             {/each}
         {/each}
         <div class="form-options">
-            <button class="clear" on:click={() => form.reset()}>Clear</button>
+            <button class="clear" on:click={clearForm}>Clear</button>
         </div>
     </form>
 </span>

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -24,7 +24,7 @@
      * @param input Value to be added to the list.
      * @param clear Whether to clear the input after adding the value.
      */
-    const addSN = (input: string = serialNumber, clear = true) => {
+    const addSN = (input: string = serialNumber, clear = false) => {
         if (input === "") return;
 
         // Prevent duplicates

--- a/frontend/src/stores.ts
+++ b/frontend/src/stores.ts
@@ -8,7 +8,7 @@ export interface AppState {
     loading: Writable<boolean>;
 }
 
-export const activeForm = writable<number | null>(null);
+export const activeForm = writable<number | null>(0);
 export const checkValidity = writable<boolean>(false);
 export const formDataStore = writable<Object>({});
 export const formValidity = writable<boolean>(false);

--- a/frontend/src/stores.ts
+++ b/frontend/src/stores.ts
@@ -8,7 +8,7 @@ export interface AppState {
     loading: Writable<boolean>;
 }
 
-export const activeForm = writable<number | null>(0);
+export const activeForm = writable<number | null>(null);
 export const checkValidity = writable<boolean>(false);
 export const formDataStore = writable<Object>({});
 export const formValidity = writable<boolean>(false);


### PR DESCRIPTION
Fixes #29 
# Changes in This PR
## Additions
Added a **Clear** button to `LabelForm` so users who don't use <kbd>Tab</kbd> for everything don't have to clear the form manually. Like the **Clear** button in `SerialNumberInput`, this action requires confirmation.

## Changes
- The `Header` component now has `z-index: 99` so that it displays over other sticky elements such as `PrintingOptions`, but not `LoadingOverlay` which has `z-index: 100`. This change doesn't affect anything in practice as you'd have to resize the window to an unusable height to see it, but it makes sense from a design standpoint.
- `SerialNumberInput` now retains its input when the `add()` function is called. This is so that serial numbers which are very similar don't need to be fully reentered every time (eg. "SN-01", then "SN-03").