### PR TITLE
Generic Label Component

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -14,6 +14,8 @@
     const STATE_FETCH_FAIL_MESSAGE = "Failed to fetch application state.";
 
     let active: number | null;
+    let selectedForm: GenericForm | LabelForm;
+
     activeForm.subscribe((value) => (active = value));
 
     onMount(async () => {
@@ -76,14 +78,22 @@
     </FormatSelector>
 
     <div class="container">
-        <GenericForm active={active === null} />
+        {#if active === null}
+            <GenericForm active={active === null} bind:this={selectedForm} />
+        {/if}
 
         {#each labelFormats as format, itemIndex}
-            <LabelForm {format} active={itemIndex === active} />
+            {#if itemIndex === active}
+                <LabelForm
+                    {format}
+                    active={itemIndex === active}
+                    bind:this={selectedForm}
+                />
+            {/if}
         {/each}
 
         <SerialNumberInput />
-        <PrintingOptions />
+        <PrintingOptions {selectedForm} />
     </div>
 </main>
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -111,18 +111,6 @@
         border-bottom: var(--bd);
     }
 
-    :global(button) {
-        border: none;
-        color: var(--text);
-        font-size: 1rem;
-        cursor: pointer;
-        background-color: var(--accent);
-    }
-
-    :global(button:hover) {
-        background-color: var(--accent-hover);
-    }
-
     :global(h1) {
         font-size: 2.5rem;
     }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,7 @@
     import { onMount } from "svelte";
     import { labelFormats } from "./companies";
     import FormatSelector from "./components/FormatSelector.svelte";
+    import GenericForm from "./components/GenericForm.svelte";
     import Header from "./components/Header.svelte";
     import LabelForm from "./components/LabelForm.svelte";
     import LoadingOverlay from "./components/LoadingOverlay.svelte";
@@ -11,7 +12,6 @@
 
     const NETWORK_ERROR_MESSAGE = "Network error. Please try again later.";
     const STATE_FETCH_FAIL_MESSAGE = "Failed to fetch application state.";
-    const NO_FORMAT_SELECTED_MESSAGE = "No label format selected.";
 
     let active: number | null;
     activeForm.subscribe((value) => (active = value));
@@ -50,6 +50,17 @@
 
 <main>
     <FormatSelector>
+        <!-- TODO: Fix these -->
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+        <h2
+            data-item="generic"
+            on:click={() => activeForm.update(() => null)}
+            class={active === null ? "active" : ""}
+        >
+            &lsqb; Generic &rsqb;
+        </h2>
+
         {#each labelFormats as labelFormat, index}
             <!-- TODO: Fix these -->
             <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -65,18 +76,14 @@
     </FormatSelector>
 
     <div class="container">
-        {#if active === null}
-            <h2 class="hero">{NO_FORMAT_SELECTED_MESSAGE}</h2>
-        {/if}
+        <GenericForm active={active === null} />
 
         {#each labelFormats as format, itemIndex}
             <LabelForm {format} active={itemIndex === active} />
         {/each}
 
-        {#if active !== null}
-            <SerialNumberInput />
-            <PrintingOptions />
-        {/if}
+        <SerialNumberInput />
+        <PrintingOptions />
     </div>
 </main>
 
@@ -98,21 +105,6 @@
 
     .container > :global(span) {
         padding: 1rem;
-    }
-
-    .container h2 {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 100%;
-    }
-
-    .hero {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        text-wrap: nowrap;
     }
 
     .container > :global(.active) {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -63,3 +63,20 @@ html {
     display: grid;
     grid-template-rows: var(--header-height) 1fr;
 }
+
+button {
+    border: none;
+    color: var(--text);
+    font-size: 1rem;
+    padding: 0.25rem 1rem;
+    background-color: var(--accent);
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: var(--accent-hover);
+}
+
+button:disabled {
+    opacity: .5;
+}

--- a/frontend/src/components/GenericForm.svelte
+++ b/frontend/src/components/GenericForm.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+    import GenericLine from "./GenericLine.svelte";
+    import { onMount } from "svelte";
     import { clearForm } from "../formHelpers";
 
     export let active: boolean = false;
 
-    let fieldCount = 1;
+    let rowCount = 0;
     let form: HTMLFormElement;
 
+    const addRow = () => rowCount++;
     const updateDataStore = () => {};
 
-    $: rows = new Array(fieldCount);
+    // Generate five rows on mount.
+    onMount(() => [...Array(5)].map(() => addRow()));
 </script>
 
 <span class="container {active ? 'active' : ''}">
@@ -18,17 +22,13 @@
             <p>Field</p>
             <p>Value</p>
         </span>
-        {#each rows as rowIndex}
-            <input name="row-{rowIndex}" />
-            <input
-                required
-                type="text"
-                id="row-{rowIndex}"
-                name="row-{rowIndex}"
-            />
+
+        {#each [...Array(rowCount)] as _}
+            <GenericLine />
         {/each}
-        <button class="add-field">&plus;</button>
+
         <div class="form-options">
+            <button on:click|preventDefault={addRow}>&plus; Row</button>
             <button class="clear" on:click={() => clearForm(form)}>
                 Clear
             </button>
@@ -45,10 +45,11 @@
 
     form {
         display: grid;
-        grid-template-columns: 8ch 1fr;
+        grid-template-columns: 10ch 1fr auto auto;
         gap: 0.5rem;
         padding: 0 10%;
         width: 100%;
+        max-width: 900px;
     }
 
     .add-field {
@@ -66,9 +67,5 @@
         grid-column: 1 / -1;
         text-align: center;
         border-bottom: var(--bd);
-    }
-
-    form > input {
-        min-width: 8ch !important;
     }
 </style>

--- a/frontend/src/components/GenericForm.svelte
+++ b/frontend/src/components/GenericForm.svelte
@@ -2,6 +2,7 @@
     import GenericLine from "./GenericLine.svelte";
     import { onMount } from "svelte";
     import { clearForm } from "../formHelpers";
+    import { formDataStore } from "../stores";
 
     export let active: boolean = false;
 
@@ -9,7 +10,25 @@
     let form: HTMLFormElement;
 
     const addRow = () => rowCount++;
-    const updateDataStore = () => {};
+    const updateDataStore = () => {
+        let data: Record<string, string>[] = [];
+        let containers = form.querySelectorAll(".container");
+
+        containers.forEach((container) => {
+            let fields = container.querySelectorAll("input");
+            let row: Record<string, string> = {};
+
+            fields.forEach((field) => {
+                row[field.name] = field.value;
+            });
+
+            data.push(row);
+        });
+
+        formDataStore.update(() => {
+            return { rows: data };
+        });
+    };
 
     // Generate five rows on mount.
     onMount(() => [...Array(5)].map(() => addRow()));

--- a/frontend/src/components/GenericForm.svelte
+++ b/frontend/src/components/GenericForm.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+    import { clearForm } from "../formHelpers";
+
+    export let active: boolean = false;
+
+    let fieldCount = 1;
+    let form: HTMLFormElement;
+
+    const updateDataStore = () => {};
+
+    $: rows = new Array(fieldCount);
+</script>
+
+<span class="container {active ? 'active' : ''}">
+    <h1>Generic Label</h1>
+    <form bind:this={form} on:input={updateDataStore}>
+        <span class="headers">
+            <p>Field</p>
+            <p>Value</p>
+        </span>
+        {#each rows as rowIndex}
+            <input name="row-{rowIndex}" />
+            <input
+                required
+                type="text"
+                id="row-{rowIndex}"
+                name="row-{rowIndex}"
+            />
+        {/each}
+        <button class="add-field">&plus;</button>
+        <div class="form-options">
+            <button class="clear" on:click={() => clearForm(form)}>
+                Clear
+            </button>
+        </div>
+    </form>
+</span>
+
+<!--
+    Ignore selectors we don't use in this component.
+    svelte-ignore css-unused-selector
+-->
+<style>
+    @import "../form.css";
+
+    form {
+        display: grid;
+        grid-template-columns: 8ch 1fr;
+        gap: 0.5rem;
+        padding: 0 10%;
+        width: 100%;
+    }
+
+    .add-field {
+        grid-column: 1 / -1;
+        justify-self: center;
+        width: 2rem;
+        height: 2rem;
+        font-size: 1.5rem;
+        font-weight: bold;
+    }
+
+    .headers {
+        display: grid;
+        grid-template-columns: inherit;
+        grid-column: 1 / -1;
+        text-align: center;
+        border-bottom: var(--bd);
+    }
+
+    form > input {
+        min-width: 8ch !important;
+    }
+</style>

--- a/frontend/src/components/GenericForm.svelte
+++ b/frontend/src/components/GenericForm.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
-    import GenericLine from "./GenericLine.svelte";
     import { onMount } from "svelte";
-    import { clearForm } from "../formHelpers";
     import {
         checkValidity,
         formDataStore,
         formValidity,
         loading,
     } from "../stores";
+    import GenericLine from "./GenericLine.svelte";
+    import { clearForm } from "../formHelpers";
 
     export let active: boolean = false;
 
-    let rowCount = 0;
     let form: HTMLFormElement;
+    let lines: GenericLine[] = [];
+    let rowCount = 0;
 
     const addRow = () => rowCount++;
+
+    const clearFields = () => {
+        clearForm(form);
+        lines.forEach((line) => line.clearFields());
+    };
 
     export const updateDataStore = () => {
         let data: Record<string, string>[] = [];
@@ -72,14 +78,12 @@
 
         {#each [...Array(rowCount)] as _, rowNumber}
             <p class="row-num">Row {rowNumber + 1}</p>
-            <GenericLine />
+            <GenericLine bind:this={lines[rowNumber]} />
         {/each}
 
         <div class="form-options">
             <button on:click|preventDefault={addRow}>&plus; Row</button>
-            <button class="clear" on:click={() => clearForm(form)}>
-                Clear
-            </button>
+            <button class="clear" on:click={clearFields}> Clear </button>
         </div>
     </form>
 </span>

--- a/frontend/src/components/GenericLine.svelte
+++ b/frontend/src/components/GenericLine.svelte
@@ -2,24 +2,25 @@
     let container: HTMLSpanElement;
     let fields: Array<{ [key: string]: string }> = [{ "": "" }];
 
-    const deleteLine = () => {
-        container.parentNode!.removeChild(container);
-    };
+    /** Remove the line and all its fields. */
+    const deleteLine = () => container.parentNode!.removeChild(container);
 
+    /** Run the given function and update the list of fields. */
     const update = (fn: Function, ...args: any[]) => {
         fn(...args);
         fields = [...fields];
     };
 
-    const add = (index: number) => {
-        fields.splice(index + 1, 0, { "": "" });
-    };
+    /** Add a new field to the line. */
+    const add = (index: number) => fields.splice(index + 1, 0, { "": "" });
 
+    /** Update the name of a field. */
     const name = (index: number, e: Event) => {
         const target = e.target as HTMLInputElement;
         fields[index] = { [target.value]: Object.values(fields[index])[0] };
     };
 
+    /** Update the value of a field. */
     const value = (index: number, e: Event) => {
         const target = e.target as HTMLInputElement;
         fields[index] = {
@@ -28,6 +29,7 @@
         };
     };
 
+    /** Remove a field from the line. */
     const remove = (index: number) => fields.splice(index, 1);
 </script>
 

--- a/frontend/src/components/GenericLine.svelte
+++ b/frontend/src/components/GenericLine.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
+    export const clearFields = () => {
+        Object.entries(fields).forEach(([key, value]) => {
+            let emptyFields: Array<{ [key: string]: string }> = [];
+            fields.forEach((_) => emptyFields.push({ "": "" }));
+            fields = emptyFields;
+        });
+    };
+
+    export let fields: Array<{ [key: string]: string }> = [{ "": "" }];
+
     let container: HTMLSpanElement;
-    let fields: Array<{ [key: string]: string }> = [{ "": "" }];
 
     /** Remove the line and all its fields. */
     const deleteLine = () => container.parentNode!.removeChild(container);
@@ -66,9 +75,9 @@
             </button>
         {/if}
 
-        <button on:click|preventDefault={() => update(add, index)}
-            >&plus;</button
-        >
+        <button on:click|preventDefault={() => update(add, index)}>
+            &plus;
+        </button>
     {/each}
 </span>
 

--- a/frontend/src/components/GenericLine.svelte
+++ b/frontend/src/components/GenericLine.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    let container: HTMLSpanElement;
+    let fields: Array<{ [key: string]: string }> = [{ "": "" }];
+
+    const deleteLine = () => {
+        container.parentNode!.removeChild(container);
+    };
+
+    const update = (fn: Function, ...args: any[]) => {
+        fn(...args);
+        fields = [...fields];
+    };
+
+    const add = (index: number) => {
+        fields.splice(index + 1, 0, { "": "" });
+    };
+
+    const name = (index: number, e: Event) => {
+        const target = e.target as HTMLInputElement;
+        fields[index] = { [target.value]: Object.values(fields[index])[0] };
+    };
+
+    const value = (index: number, e: Event) => {
+        const target = e.target as HTMLInputElement;
+        fields[index] = {
+            ...fields[index],
+            [Object.keys(fields[index])[0]]: target.value,
+        };
+    };
+
+    const remove = (index: number) => fields.splice(index, 1);
+</script>
+
+<span class="container" bind:this={container}>
+    {#each fields as _, index}
+        <input
+            name="field-{index}-name"
+            on:input={(e) => update(name, index, e)}
+            value={Object.keys({ ...fields[index] })[0]}
+        />
+        <input
+            required
+            name="field-{index}-value"
+            on:input={(e) => update(value, index, e)}
+            value={Object.values(fields[index])}
+        />
+
+        {#if fields.length === 1}
+            <button
+                on:click|preventDefault={deleteLine}
+                class="delete"
+                title="Delete row"
+            >
+                &times;
+            </button>
+        {:else}
+            <button
+                on:click|preventDefault={() => update(remove, index)}
+                disabled={Object.keys({ ...fields }).length === 1}
+                value={fields[index].toString()}
+                title="Delete field"
+            >
+                &times;
+            </button>
+        {/if}
+
+        <button on:click|preventDefault={() => update(add, index)}
+            >&plus;</button
+        >
+    {/each}
+</span>
+
+<style>
+    .container {
+        position: relative;
+        grid-column: 1 / -1;
+        display: grid;
+        grid-template-columns: inherit;
+        gap: 0.5rem;
+        width: 100%;
+    }
+
+    .container::after {
+        content: "";
+        display: block;
+        grid-column: 1 / -1;
+        border-bottom: var(--bd);
+    }
+
+    .delete {
+        font-weight: bold;
+    }
+</style>

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -13,7 +13,7 @@
     let form: HTMLFormElement;
     let rows: object[] = new Array(format.length);
 
-    const updateDataStore = () => {
+    export const updateDataStore = () => {
         if (!active) return;
 
         // Group form data by row defined in format
@@ -29,7 +29,6 @@
         });
     };
 
-    $: active && updateDataStore();
     $: if (active && $checkValidity) {
         if (form.checkValidity()) {
             formValidity.set(true);
@@ -45,7 +44,7 @@
 
 <span class="container {active ? 'active' : ''}">
     <h1>Label Fields</h1>
-    <form bind:this={form} on:input={updateDataStore}>
+    <form bind:this={form}>
         {#each format.rows as row, index}
             {#each row as field}
                 <label for={field}>{field}</label>

--- a/frontend/src/components/LabelForm.svelte
+++ b/frontend/src/components/LabelForm.svelte
@@ -5,6 +5,7 @@
         formValidity,
         loading,
     } from "../stores";
+    import { formObj, clearForm } from "../formHelpers";
 
     export let format: { [key: string]: any };
     export let active: boolean = false;
@@ -12,17 +13,11 @@
     let form: HTMLFormElement;
     let rows: object[] = new Array(format.length);
 
-    const formObj = () => Object.fromEntries(new FormData(form));
-
-    const clearForm = () => {
-        if (confirm("Clear all fields?")) form.reset();
-    };
-
     const updateDataStore = () => {
         if (!active) return;
 
         // Group form data by row defined in format
-        let data = formObj();
+        let data = formObj(form);
         format.rows.map((row: string[], index: number) => {
             row.forEach((field: string) => {
                 rows[index] = { ...rows[index], [field]: data[field] };
@@ -64,60 +59,13 @@
             {/each}
         {/each}
         <div class="form-options">
-            <button class="clear" on:click={clearForm}>Clear</button>
+            <button class="clear" on:click={() => clearForm(form)}>
+                Clear
+            </button>
         </div>
     </form>
 </span>
 
 <style>
-    .container {
-        position: relative;
-        display: none;
-    }
-
-    .active {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-    }
-
-    .form-options {
-        display: flex;
-        justify-content: flex-end;
-        grid-column: 1/-1;
-        width: 100%;
-    }
-
-    .form-options > button {
-        padding: 0.25rem 2rem;
-    }
-
-    form {
-        display: grid;
-        grid-template-columns: auto 1fr;
-        align-items: center;
-        gap: 1rem;
-
-        margin: 0 auto;
-        width: 50%;
-        font-size: 1.5rem;
-        border: none;
-    }
-
-    form > input {
-        min-width: 300px;
-        width: 100%;
-    }
-
-    form > label {
-        padding-left: 1rem;
-        text-align: right;
-        white-space: nowrap;
-    }
-
-    h1 {
-        width: 100%;
-        font-size: 1.5rem;
-        text-align: center;
-    }
+    @import "../form.css";
 </style>

--- a/frontend/src/components/PrintingOptions.svelte
+++ b/frontend/src/components/PrintingOptions.svelte
@@ -6,6 +6,10 @@
         loading,
         serialNumberList,
     } from "../stores";
+    import GenericForm from "./GenericForm.svelte";
+    import LabelForm from "./LabelForm.svelte";
+
+    export let selectedForm: GenericForm | LabelForm;
 
     let printMultiple: boolean = false;
     let specifyQty: boolean = false;
@@ -22,6 +26,7 @@
             return;
         }
 
+        selectedForm.updateDataStore();
         formDataStore.update((data) => {
             return {
                 ...data,

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -76,11 +76,15 @@
         // Matches the following formats (prefix is optional):
         // 1. "ABC123" => ["ABC", "123"]
         // 2. "ABC-123" => ["ABC-", "123"]
-        const match = input.match(/(.*[^\d])(\d+$)/);
+        const match = input.match(/(.*[^\d])?(\d+$)/);
 
         if (!match) return;
 
-        const [_, prefix, num] = match;
+        let [_, prefix, num] = match;
+
+        // Ensure prefix is not `undefined`
+        prefix ?? (prefix = "");
+
         const incremented = (parseInt(num, 10) + 1)
             .toString()
             .padStart(num.length, "0");

--- a/frontend/src/components/SerialNumberInput.svelte
+++ b/frontend/src/components/SerialNumberInput.svelte
@@ -76,7 +76,7 @@
         // Matches the following formats (prefix is optional):
         // 1. "ABC123" => ["ABC", "123"]
         // 2. "ABC-123" => ["ABC-", "123"]
-        const match = input!.match(/^([a-zA-Z-]*)(\d+$)/);
+        const match = input.match(/(.*[^\d])(\d+$)/);
 
         if (!match) return;
 

--- a/frontend/src/form.css
+++ b/frontend/src/form.css
@@ -1,0 +1,50 @@
+.container {
+    position: relative;
+    display: none;
+}
+
+.active {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.form-options {
+    display: flex;
+    justify-content: flex-end;
+    grid-column: 1/-1;
+    width: 100%;
+}
+
+.form-options>button {
+    padding: 0.25rem 2rem;
+}
+
+form {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 1rem;
+
+    margin: 0 auto;
+    width: 50%;
+    font-size: 1.5rem;
+    border: none;
+}
+
+form>input {
+    min-width: 300px;
+    width: 100%;
+}
+
+form>label {
+    padding-left: 1rem;
+    text-align: right;
+    white-space: nowrap;
+}
+
+h1 {
+    width: 100%;
+    font-size: 1.5rem;
+    text-align: center;
+}

--- a/frontend/src/formHelpers.ts
+++ b/frontend/src/formHelpers.ts
@@ -1,0 +1,5 @@
+export const formObj = (form: HTMLFormElement) =>
+    Object.fromEntries(new FormData(form));
+
+export const clearForm = (form: HTMLFormElement) =>
+    confirm("Clear all fields?") ? form.reset() : null;


### PR DESCRIPTION
# Changes in This PR
Resolves #35
- Replaced "No label format selected" text with Generic label form
- `GenericForm` and `GenericLine` components
- Improved (fixed) serial number incrementing
- Version updated to v3.1

## Generic Label Form
The new default label format will be the **Generic** label, which has blank inputs for each field's name and value. The user can add fields to each row as well as add new rows as needed. Removing all rows is still allowed, but only information entered in `SerialNumberInput` or `PrintingOptions` will be present on the resulting label(s).

![image](https://github.com/machspec/labelmaker3/assets/63938746/f76ff5ed-0bf6-4b4f-a3f1-f9052188ca45)

Improving on the original program's implementation, each generic row can now have multiple fields (eg. "**PN: XXXXXX Rev: A**" on one line). The **&plus;** button inserts a new field immediately after the form on which the button was pressed. Clicking the **&plus; Row** button will insert a new row.

Clicking the **&times;** button when there are multiple fields in a row will delete the specific field where the button was clicked, but clicking it when there is only one field will remove that row. The &times; will display in **bold** when its function is to delete the entire row instead of a single field.